### PR TITLE
⚡️ Remove positive lookahead for non-zero bytes

### DIFF
--- a/diff/bin/src/diff.rs
+++ b/diff/bin/src/diff.rs
@@ -43,6 +43,9 @@ fn main() -> Result<()> {
     // Initialize the tracing subscriber
     init_tracing_subscriber(v)?;
 
+    // Trim the leading "0x" if it exists.
+    let in_bytes = in_bytes.trim_start_matches("0x").to_string();
+
     match mode {
         Mode::ZeroKompress => {
             tracing::info!(target: "diff_cli", "Attempting to ZeroKompress input bytes: {:?}", in_bytes);

--- a/diff/crates/zero-kompressor/src/lib.rs
+++ b/diff/crates/zero-kompressor/src/lib.rs
@@ -35,14 +35,12 @@ pub fn zero_dekompress(bytes: String) -> Result<String> {
 
     let mut iter = bytes.into_iter().peekable();
     while let Some(byte) = iter.next() {
-        if let Some(&next_byte) = iter.peek() {
-            if next_byte == 0 {
-                // Fill `byte` number of 0s into the result array
+        if byte == 0 {
+            if let Some(&next_byte) = iter.peek() {
                 iter.next();
-                result.resize(result.len() + byte as usize, 0);
+                result.resize(result.len() + next_byte as usize, 0);
             } else {
-                // Copy `byte` into the result array
-                result.push(byte);
+                anyhow::bail!("Invalid input");
             }
         } else {
             // Copy `byte` into the result array
@@ -55,8 +53,8 @@ pub fn zero_dekompress(bytes: String) -> Result<String> {
 /// Append RLE zeros to the vector if necessary
 fn fill_zeros(v: &mut Vec<u8>, num_zeros: &mut u8) {
     if *num_zeros > 0 {
-        v.push(*num_zeros);
         v.push(0);
+        v.push(*num_zeros);
         *num_zeros = 0;
     }
 }
@@ -67,7 +65,7 @@ mod test {
     pub fn test_zero_kompress_middle() {
         let input_value = String::from("7f6b590c000000000000220000ff");
         let output_value = super::zero_kompress(input_value).unwrap();
-        let expected_value = String::from("7f6b590c0600220200ff");
+        let expected_value = String::from("7f6b590c0006220002ff");
         assert_eq!(output_value, expected_value);
     }
 
@@ -75,7 +73,7 @@ mod test {
     pub fn test_zero_kompress_edge_end() {
         let input_value = String::from("00000000ff");
         let output_value = super::zero_kompress(input_value).unwrap();
-        let expected_value = String::from("0400ff");
+        let expected_value = String::from("0004ff");
         assert_eq!(output_value, expected_value);
     }
 
@@ -83,7 +81,7 @@ mod test {
     pub fn test_zero_kompress_edge_start() {
         let input_value = String::from("ff00000000");
         let output_value = super::zero_kompress(input_value).unwrap();
-        let expected_value = String::from("ff0400");
+        let expected_value = String::from("ff0004");
         assert_eq!(output_value, expected_value);
     }
 
@@ -91,7 +89,7 @@ mod test {
     pub fn test_zero_kompress_zero_rollover() {
         let input_value = String::from("00").repeat(260);
         let output_value = super::zero_kompress(input_value).unwrap();
-        let expected_value = String::from("ff000500");
+        let expected_value = String::from("00ff0005");
         assert_eq!(output_value, expected_value);
     }
 
@@ -99,13 +97,13 @@ mod test {
     pub fn test_zero_kompress_zero_rollover_multiple() {
         let input_value = String::from("00").repeat(255 * 2 + 5);
         let output_value = super::zero_kompress(input_value).unwrap();
-        let expected_value = String::from("ff00ff000500");
+        let expected_value = String::from("00ff00ff0005");
         assert_eq!(output_value, expected_value);
     }
 
     #[test]
     pub fn test_zero_dekompress_middle() {
-        let input_value = String::from("7f6b590c0600220200ff");
+        let input_value = String::from("7f6b590c0006220002ff");
         let output_value = super::zero_dekompress(input_value).unwrap();
         let expected_value = String::from("7f6b590c000000000000220000ff");
         assert_eq!(output_value, expected_value);
@@ -113,7 +111,7 @@ mod test {
 
     #[test]
     pub fn test_zero_dekompress_edge_end() {
-        let input_value = String::from("0400ff");
+        let input_value = String::from("0004ff");
         let output_value = super::zero_dekompress(input_value).unwrap();
         let expected_value = String::from("00000000ff");
         assert_eq!(output_value, expected_value);
@@ -121,7 +119,7 @@ mod test {
 
     #[test]
     pub fn test_zero_dekompress_edge_start() {
-        let input_value = String::from("ff0400");
+        let input_value = String::from("ff0004");
         let output_value = super::zero_dekompress(input_value).unwrap();
         let expected_value = String::from("ff00000000");
         assert_eq!(output_value, expected_value);
@@ -129,7 +127,7 @@ mod test {
 
     #[test]
     pub fn test_zero_dekompress_zero_rollover() {
-        let input_value = String::from("ff000500");
+        let input_value = String::from("00ff0005");
         let output_value = super::zero_dekompress(input_value).unwrap();
         let expected_value = String::from("00").repeat(260);
         assert_eq!(output_value, expected_value);
@@ -137,7 +135,7 @@ mod test {
 
     #[test]
     pub fn test_zero_dekompress_zero_rollover_multiple() {
-        let input_value = String::from("ff00ff000500");
+        let input_value = String::from("00ff00ff0005");
         let output_value = super::zero_dekompress(input_value).unwrap();
         let expected_value = String::from("00").repeat(255 * 2 + 5);
         assert_eq!(output_value, expected_value);


### PR DESCRIPTION
## Overview

Alters the encoding scheme to remove the requirement for a positive lookahead for all bytes.

Instead of encoding zero bytes as `<length>00`, they are now encoded as `00<length>`.